### PR TITLE
Includes new validator 'A mobile phone or an empty string'

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "common-bacon-form",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "homepage": "https://github.com/meedoc/meedoc-common",
   "authors": [
     "JaakkoL <jaakko.o.laurila@gmail.com>"

--- a/dist/common-bacon-form.js
+++ b/dist/common-bacon-form.js
@@ -307,6 +307,7 @@
         'IS_EMPTY_STRING' : function isEmpty(val) { return val === "" },
         'AUTH_CODE': function authCode(val) { return val.length === 5 },
         'MOBILE_WITH_PREFIX' : function containsCountryCode(val) { return /^(?:00|\+)[0-9\s]{6,20}$/.test(val) },
+        'MOBILE_WITH_PREFIX_OR_EMPTY' : function containsCountryCode(val) { return (val==='')?true:/^(?:00|\+)[0-9\s]{6,20}$/.test(val) },
         'MOBILE' : function containsCountryCode(val) { return /^[0-9\s]{6,20}$/.test(val) },
         'IS_TRUE' : function isTrue(bool) { return bool === true },
         'IS_FALSE' : function isFalse(bool) { return false },


### PR DESCRIPTION
CORRECTED
- Renamed to MOBILE_WITH_PREFIX_OR_EMPTY

USED BY
- https://github.com/meedoc/meedoc-admin/pull/80

Needed for #637 https://trello.com/c/lIXiEOyQ
